### PR TITLE
Security: Production build configured to emit source maps

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default defineConfig([
     input: "./lib/browser/jcode.mjs",
     output: {
       dir: "dist",
-      sourcemap: true,
+      sourcemap: false,
       format: "esm",
       entryFileNames: "[name].js",
     },
@@ -37,13 +37,13 @@ export default defineConfig([
     output: [
       {
         dir: "dist",
-        sourcemap: true,
+        sourcemap: false,
         format: "esm",
         entryFileNames: "[name].[format].js",
       },
       {
         dir: "dist",
-        sourcemap: true,
+        sourcemap: false,
         format: "umd",
         name: 'Judger',
         entryFileNames: "[name].[format].js",


### PR DESCRIPTION
## Problem

Rollup outputs are configured with `sourcemap: true` for distributable browser bundles. If these maps are published with production assets, attackers can reconstruct original source code and comments, making reverse engineering and vulnerability discovery significantly easier.

**Severity**: `medium`
**File**: `rollup.config.js`

## Solution

Disable source maps for production releases (`sourcemap: false`) or generate hidden/private maps only for internal debugging. Ensure `.map` files are not publicly served.

## Changes

- `rollup.config.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
